### PR TITLE
proxy to the vue server

### DIFF
--- a/BackEnd/app.js
+++ b/BackEnd/app.js
@@ -7,6 +7,7 @@ import routes from './routes';
 
 const app = express();
 const port = process.env.PORT || 3000;
+const VUE_PROXY_URL = process.env.VUE_PROXY_URL || 'http://localhost:8080';
 
 app.use(bodyParser.json());
 
@@ -32,6 +33,6 @@ app.use(function (req, res, next) {
 });
 
 app.use('/api', routes);
-app.use('/', proxy('http://localhost:8080'));
+app.use('/', proxy(VUE_PROXY_URL));
 
 app.listen(port, () => console.log(`Example app listening on port ${port}!`))

--- a/BackEnd/app.js
+++ b/BackEnd/app.js
@@ -1,7 +1,7 @@
 import express from 'express';
-import cookieSession from 'cookie-session';
 import bodyParser from 'body-parser';
 import session from 'express-session';
+import proxy from 'express-http-proxy';
 
 import routes from './routes';
 
@@ -31,11 +31,7 @@ app.use(function (req, res, next) {
   next()
 });
 
-
-app.get('/', (req, res) => {
-  res.send("Hello");
-})
-
 app.use('/api', routes);
+app.use('/', proxy('http://localhost:8080'));
 
 app.listen(port, () => console.log(`Example app listening on port ${port}!`))

--- a/BackEnd/package-lock.json
+++ b/BackEnd/package-lock.json
@@ -2080,8 +2080,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2102,14 +2101,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2124,20 +2121,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2254,8 +2248,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2267,7 +2260,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2282,7 +2274,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2290,14 +2281,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2316,7 +2305,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2397,8 +2385,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2410,7 +2397,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2496,8 +2482,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2533,7 +2518,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2553,7 +2537,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2597,14 +2580,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },


### PR DESCRIPTION
With this if the vue server is running on localhost:8080 the api server will proxy to it, catching the requests to `/api` requests. This lets us call the api locally without worrying about CORS.